### PR TITLE
Update Drupal Module Repository URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "pacifica-dev": {
             "no-api": true,
             "type": "vcs",
-            "url": "https://github.com/pacifica/pacifica-drupal-module.git"
+            "url": "https://git.drupalcode.org/project/pacifica.git"
         },
         "pacifica-profiles-dev": {
             "no-api": true,


### PR DESCRIPTION
This updates the Drupal Pacifica module repository URL to the
upstream project at drupal.org.

Signed-off-by: David Brown <dmlb2000@gmail.com>